### PR TITLE
Update wininet.rs

### DIFF
--- a/src/um/wininet.rs
+++ b/src/um/wininet.rs
@@ -1748,7 +1748,7 @@ extern "system" {
     pub fn HttpAddRequestHeadersW(
         hRequest: HINTERNET,
         lpszHeaders: LPCWSTR,
-        dwHeadersLength: i8,
+        dwHeadersLength: i32,
         dwModifiers: DWORD,
     ) -> BOOL;
     pub fn HttpEndRequestA(


### PR DESCRIPTION
Sorry last one generate and excepcion handle , it's necessary to work use i32 in dwHeadersLength.